### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # KF Autotune
 
 This project will handle Python based kalman filter autotuning code.
-Details are not desined yet.
+Details are not designed yet.
 
-## 1 dimentional kf optimization
+## 1-dimensional KF optimization
 
-Try run 
+Try running
 
 ```
 python3 mock/kf_auto_tune_sample1d.py

--- a/kf_auto_tuning/sample_config.yaml
+++ b/kf_auto_tuning/sample_config.yaml
@@ -1,0 +1,20 @@
+system_config:
+  F: [[1, 0.1], [0, 1]]
+  G: [[0], [1]]
+  H: [[1, 0]]
+  Q_true: [0.0]
+  R_true: 0.5
+  x0: [0, 1]
+  P0: [[1, 0], [0, 1]]
+  u: 0
+  steps: 100
+  nx: 2
+  nz: 1
+  data_seed: 42
+
+optimization_config:
+  param_bounds:
+    Q: [0.01, 1.0]
+    R: [0.1, 1.0]
+  n_calls: 30
+  opt_seed: 42


### PR DESCRIPTION
## Summary
- fix typos in README instructions
- add missing sample config for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f400e093c83299bc4457c4d15903d